### PR TITLE
Add client certificates option to cargo

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -558,6 +558,18 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     if let Some(proxy) = http_proxy(config)? {
         handle.proxy(&proxy)?;
     }
+    if let Some(client_ssl_cert) = &http.client_ssl_cert{
+        let client_ssl_cert= client_ssl_cert.resolve_path(config);
+        handle.ssl_cert(&client_ssl_cert)?;
+        handle.ssl_cert_type("PEM")?;
+    }
+    if let Some(client_ssl_key) = &http.client_ssl_key{
+        let client_ssl_key= client_ssl_key.resolve_path(config);
+        handle.ssl_key(&client_ssl_key)?;
+    }
+    if let Some(client_ssl_key_password) = &http.client_ssl_key_password{
+        handle.key_password(client_ssl_key_password.as_str())?;
+    }
     if let Some(cainfo) = &http.cainfo {
         let cainfo = cainfo.resolve_path(config);
         handle.cainfo(&cainfo)?;

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2117,6 +2117,9 @@ pub struct CargoHttpConfig {
     pub debug: Option<bool>,
     pub multiplexing: Option<bool>,
     pub ssl_version: Option<SslVersionConfig>,
+    pub client_ssl_cert: Option<ConfigRelativePath>,
+    pub client_ssl_key: Option<ConfigRelativePath>,
+    pub client_ssl_key_password: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]


### PR DESCRIPTION
This PR focus on adding a functionality that will allow to use client certificate when dealing with private registry. This allow to secure the front end of the private registry with a client certificate while still being able to communicate the api via cargo.

Eg in $HOME/.cargo/config
```toml
[http]
client-ssl-cert = "/etc/ssl/client.pem"
client-ssl-key = "/etc/ssl/key.pem"
client-ssl-key-password = "<password>"
```
